### PR TITLE
Always use braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,9 +521,6 @@
     if (test)
       return false;
 
-    // good (only for very simple statements and early function return)
-    if (test) return false;
-
     // good
     if (test) {
       return false;
@@ -536,6 +533,9 @@
     function () {
       return false;
     }
+
+    // acceptable (only for very simple statements and early function return)
+    if (test) return false;
     ```
 
     **[[⬆]](#TOC)**


### PR DESCRIPTION
I'm OK with saying that people can omit braces in a unique particular instance if they want, but, I am extremely uncomfortable dictating that they must not use braces in some subjective instances. I find it an acceptable evil to ommit braces in some cases if you really want, but, would rather the consistency of just saying "always use braces".
