### PR TITLE
Add jscs lint configuration.

### DIFF
--- a/linters/.jscsrc
+++ b/linters/.jscsrc
@@ -1,0 +1,6 @@
+{
+    "preset": "airbnb",
+    "validateLineBreaks": null,
+    "disallowQuotedKeysInObjects": "allButReserved",
+    "validateIndentation": "\t"
+}


### PR DESCRIPTION
You can see the airbnb rules [here](https://github.com/jscs-dev/node-jscs/blob/master/presets/airbnb.json)
The full rule list [here](http://jscs.info/rules.html)

preset === follow their rules other than listed exceptions.

Exception reasoning-
 - validateLineBreaks - windows editors use CRLF by default some editors (Atom) don't allow you to change this, but git converts to LF by default automagically anyway.
 - disallowQuotedKeysInOjbect - Changed this rule to allow for javascript styles in react based projects. (float is a reserved word, but valid css key)
 - validateIndentation - Styleguide currently says to use tabs, they use 2 spaces.